### PR TITLE
display tools in middleware tab items

### DIFF
--- a/lib/sagents_live_debugger/layouts.ex
+++ b/lib/sagents_live_debugger/layouts.ex
@@ -1047,6 +1047,44 @@ defmodule SagentsLiveDebugger.Layouts do
       background: #9ca3af;
     }
 
+    /* Middleware Tools Section */
+    .middleware-tools {
+      margin-top: 0.75rem;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+      background: #fafafa;
+    }
+
+    .middleware-tools-header {
+      padding: 0.5rem 1rem;
+      background: #f3f4f6;
+      border-bottom: 1px solid #e5e7eb;
+      border-radius: 0.375rem 0.375rem 0 0;
+    }
+
+    .middleware-tools-header .config-label {
+      margin: 0;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .middleware-tools .list-card {
+      border: none;
+      border-radius: 0;
+      margin: 0;
+    }
+
+    .middleware-tools .list-item {
+      border-left: none;
+      border-right: none;
+      border-radius: 0;
+    }
+
+    .middleware-tools .list-item:last-child {
+      border-bottom: none;
+    }
+
     /* Events Tab Styles */
     .events-tab {
       padding: 20px;

--- a/lib/sagents_live_debugger/live/components/message_components.ex
+++ b/lib/sagents_live_debugger/live/components/message_components.ex
@@ -388,6 +388,7 @@ defmodule SagentsLiveDebugger.Live.Components.MessageComponents do
       |> assign(:middleware_id, middleware_id)
       |> assign(:toggle_id, toggle_id)
       |> assign(:prefix, prefix)
+      |> assign(:tools, Sagents.Middleware.get_tools(assigns.entry))
 
     ~H"""
     <div class="list-item">
@@ -412,6 +413,19 @@ defmodule SagentsLiveDebugger.Live.Components.MessageComponents do
             <%= for {key, value} <- @config_without_special do %>
               <.middleware_config_entry key={key} value={value} />
             <% end %>
+          </div>
+        <% end %>
+
+        <%= if @tools != [] do %>
+          <div class="middleware-tools">
+            <div class="middleware-tools-header">
+              <span class="config-label">Tools ({length(@tools)})</span>
+            </div>
+            <div class="list-card">
+              <%= for tool <- @tools do %>
+                <.tool_item tool={tool} prefix={"#{@prefix}mw-#{:erlang.phash2(@entry.id)}-"} />
+              <% end %>
+            </div>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
When inspecting an Agent, the middleware tab now displays the tools included with that middleware. Making it easier to get a clear picture of where any given tool is coming from.