### PR TITLE
Fix JS and styles for standalone LiveView integration

### DIFF
--- a/lib/sagents_live_debugger/assets.ex
+++ b/lib/sagents_live_debugger/assets.ex
@@ -1,0 +1,81 @@
+defmodule SagentsLiveDebugger.Assets do
+  @moduledoc false
+
+  # Plug that serves self-contained LiveView JavaScript for the debugger.
+  #
+  # At compile time, this module reads and concatenates the pre-built JS files
+  # from phoenix, phoenix_html, and phoenix_live_view dependencies, plus a
+  # small LiveSocket initialization script. The result is served via a Plug
+  # route with cache-busting MD5 hash in the URL.
+  #
+  # This follows the same pattern as Phoenix.LiveDashboard.Assets.
+
+  import Plug.Conn
+
+  # Read Phoenix dependency JS files at compile time
+  phoenix_js_paths =
+    for app <- [:phoenix, :phoenix_html, :phoenix_live_view] do
+      path = Application.app_dir(app, ["priv", "static", "#{app}.js"])
+      Module.put_attribute(__MODULE__, :external_resource, path)
+      path
+    end
+
+  # Minimal LiveSocket initialization script.
+  # After the concatenated Phoenix JS files load, `Phoenix` and `LiveView`
+  # are available as globals. This connects the LiveSocket so the page
+  # becomes interactive.
+  @init_js """
+  (function() {
+    var socketPath = document.querySelector("html").getAttribute("phx-socket") || "/live";
+    var csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
+    var liveSocket = new LiveView.LiveSocket(socketPath, Phoenix.Socket, {
+      params: function() { return {_csrf_token: csrfToken}; }
+    });
+
+    // Attempt WebSocket first, fall back to long polling on connection error
+    var rawSocket = liveSocket.socket;
+    var originalOnConnError = rawSocket.onConnError;
+    var firstConnect = true;
+
+    rawSocket.onOpen(function() { firstConnect = false; });
+    rawSocket.onConnError = function() {
+      if (firstConnect) {
+        firstConnect = false;
+        rawSocket.disconnect(null, 3000);
+        rawSocket.transport = Phoenix.LongPoll;
+        rawSocket.connect();
+      } else {
+        originalOnConnError.apply(rawSocket, arguments);
+      }
+    };
+
+    window.addEventListener("phx:page-loading-start", function() {});
+    window.addEventListener("phx:page-loading-stop", function() {});
+
+    liveSocket.connect();
+    window.liveSocket = liveSocket;
+  })();
+  """
+
+  @js Enum.map_join(phoenix_js_paths, "\n", fn path ->
+        path |> File.read!() |> String.replace("//# sourceMappingURL=", "// ")
+      end) <> "\n" <> @init_js
+
+  @js_hash Base.encode16(:crypto.hash(:md5, @js), case: :lower)
+
+  def init(asset) when asset in [:js], do: asset
+
+  def call(conn, :js) do
+    conn
+    |> put_resp_header("content-type", "text/javascript")
+    |> put_resp_header("cache-control", "public, max-age=31536000, immutable")
+    |> put_private(:plug_skip_csrf_protection, true)
+    |> send_resp(200, @js)
+    |> halt()
+  end
+
+  @doc """
+  Returns the current MD5 hash for the JS bundle.
+  """
+  def current_hash(:js), do: @js_hash
+end

--- a/lib/sagents_live_debugger/layouts.ex
+++ b/lib/sagents_live_debugger/layouts.ex
@@ -2,24 +2,51 @@ defmodule SagentsLiveDebugger.Layouts do
   use Phoenix.Component
   import Phoenix.HTML, only: [raw: 1]
 
-  def app(assigns) do
+  @compile {:no_warn_undefined, Phoenix.VerifiedRoutes}
+
+  def root(assigns) do
     ~H"""
     <!DOCTYPE html>
-    <html lang="en">
+    <html lang="en" phx-socket={live_socket_path(@conn)}>
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="csrf-token" content={Phoenix.Controller.get_csrf_token()} />
         <title>Agent Debugger</title>
 
         <style>
           <%= raw(css()) %>
         </style>
+
+        <script src={asset_path(@conn, :js)} defer>
+        </script>
       </head>
       <body>
         {@inner_content}
       </body>
     </html>
     """
+  end
+
+  def app(assigns) do
+    ~H"""
+    {@inner_content}
+    """
+  end
+
+  defp live_socket_path(conn) do
+    [Enum.map(conn.script_name, &["/" | &1]) | conn.private.live_socket_path]
+  end
+
+  defp asset_path(conn, :js) do
+    hash = SagentsLiveDebugger.Assets.current_hash(:js)
+    prefix = conn.private.phoenix_router.__sagents_debugger_prefix__()
+
+    Phoenix.VerifiedRoutes.unverified_path(
+      conn,
+      conn.private.phoenix_router,
+      "#{prefix}/js-#{hash}"
+    )
   end
 
   defp css do

--- a/lib/sagents_live_debugger/layouts.ex
+++ b/lib/sagents_live_debugger/layouts.ex
@@ -303,18 +303,35 @@ defmodule SagentsLiveDebugger.Layouts do
       color: #1f2937;
     }
 
-    .btn-back {
-      padding: 0.5rem 1rem;
+    .btn-primary {
       background: #6366f1;
       color: white;
-      text-decoration: none;
+      padding: 0.5rem 1rem;
+      border: none;
       border-radius: 0.375rem;
       font-weight: 500;
+      cursor: pointer;
       transition: background 0.2s;
     }
 
-    .btn-back:hover {
+    .btn-primary:hover {
       background: #4f46e5;
+    }
+
+    .btn-secondary {
+      background: white;
+      color: #374151;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .btn-secondary:hover {
+      background: #f3f4f6;
+      border-color: #9ca3af;
     }
 
     .auto-refresh {
@@ -1923,36 +1940,6 @@ defmodule SagentsLiveDebugger.Layouts do
       margin-top: 1rem;
     }
 
-    .filter-actions .btn-primary {
-      background: #6366f1;
-      color: white;
-      padding: 0.5rem 1rem;
-      border: none;
-      border-radius: 0.375rem;
-      font-weight: 500;
-      cursor: pointer;
-      transition: background 0.2s;
-    }
-
-    .filter-actions .btn-primary:hover {
-      background: #4f46e5;
-    }
-
-    .filter-actions .btn-secondary {
-      background: white;
-      color: #374151;
-      padding: 0.5rem 1rem;
-      border: 1px solid #d1d5db;
-      border-radius: 0.375rem;
-      font-weight: 500;
-      cursor: pointer;
-      transition: all 0.2s;
-    }
-
-    .filter-actions .btn-secondary:hover {
-      background: #f3f4f6;
-      border-color: #9ca3af;
-    }
 
     .presence-status {
       display: flex;

--- a/lib/sagents_live_debugger/live/agent_list_live.ex
+++ b/lib/sagents_live_debugger/live/agent_list_live.ex
@@ -1219,11 +1219,11 @@ defmodule SagentsLiveDebugger.AgentListLive do
           <h2>Agent Not Found</h2>
           <p>Agent {@selected_agent_id} doesn't appear to be active.</p>
           <p class="text-muted">It may have stopped or completed its work.</p>
-          <button phx-click="back_to_list" class="btn-back">← Back to Agent List</button>
+          <button phx-click="back_to_list" class="btn btn-primary">← Back to Agent List</button>
         </div>
       <% else %>
         <div class="agent-detail-header">
-          <button phx-click="back_to_list" class="btn-back">← Back to List</button>
+          <button phx-click="back_to_list" class="btn btn-primary">← Back to List</button>
           <h2>Agent: {@selected_agent_id}</h2>
         </div>
 

--- a/lib/sagents_live_debugger/router.ex
+++ b/lib/sagents_live_debugger/router.ex
@@ -4,27 +4,45 @@ defmodule SagentsLiveDebugger.Router do
   """
 
   defmacro sagents_live_debugger(path, opts \\ []) do
-    quote bind_quoted: [path: path, opts: opts] do
-      scope path, alias: false, as: false do
-        import Phoenix.LiveView.Router, only: [live: 3, live: 4, live_session: 3]
+    scope =
+      quote bind_quoted: [path: path, opts: opts] do
+        scope path, alias: false, as: false do
+          import Phoenix.Router, only: [get: 4]
+          import Phoenix.LiveView.Router, only: [live: 3, live: 4, live_session: 3]
 
-        # Extract and validate required configuration
-        coordinator = Keyword.fetch!(opts, :coordinator)
+          # Extract and validate required configuration
+          coordinator = Keyword.fetch!(opts, :coordinator)
 
-        # Optional: Presence tracking for real-time viewer updates
-        # If not provided, viewer counts will only update on polling
-        presence_module = Keyword.get(opts, :presence_module)
+          # Optional: Presence tracking for real-time viewer updates
+          presence_module = Keyword.get(opts, :presence_module)
 
-        # Use live_session to pass configuration via session
-        live_session :sagents_debugger,
-          session: %{
-            "coordinator" => coordinator,
-            "presence_module" => presence_module
-          },
-          on_mount: [SagentsLiveDebugger.SessionConfig],
-          layout: {SagentsLiveDebugger.Layouts, :app} do
-          live "/", SagentsLiveDebugger.AgentListLive, :home
+          # Optional: custom live socket path (defaults to "/live")
+          live_socket_path = Keyword.get(opts, :live_socket_path, "/live")
+
+          live_session :sagents_debugger,
+            session: %{
+              "coordinator" => coordinator,
+              "presence_module" => presence_module
+            },
+            on_mount: [SagentsLiveDebugger.SessionConfig],
+            root_layout: {SagentsLiveDebugger.Layouts, :root},
+            layout: {SagentsLiveDebugger.Layouts, :app} do
+            # Self-contained JS asset route (cache-busted via MD5 hash)
+            get "/js-:md5", SagentsLiveDebugger.Assets, :js, as: :sagents_debugger_asset
+
+            live "/", SagentsLiveDebugger.AgentListLive, :home,
+              private: %{live_socket_path: live_socket_path}
+          end
         end
+      end
+
+    quote do
+      unquote(scope)
+
+      unless Module.get_attribute(__MODULE__, :sagents_debugger_prefix) do
+        @sagents_debugger_prefix Phoenix.Router.scoped_path(__MODULE__, unquote(path))
+                                 |> String.replace_suffix("/", "")
+        def __sagents_debugger_prefix__, do: @sagents_debugger_prefix
       end
     end
   end


### PR DESCRIPTION
## Problem

When `sagents_live_debugger` is mounted in a host Phoenix application that doesn't already load Phoenix LiveView's JavaScript assets, the debugger is non-functional -- LiveSocket never connects, so the page is static. Additionally, button styles were scoped too narrowly under `.filter-actions`, causing inconsistent appearance elsewhere in the UI.

## Solution

Follow the same self-contained asset pattern used by `Phoenix.LiveDashboard`: read the pre-built JS files from `phoenix`, `phoenix_html`, and `phoenix_live_view` at compile time, bundle them with a minimal LiveSocket initialization script, and serve the result from a cache-busted Plug route. A proper root layout now injects the `<script>` tag, CSRF meta, and `phx-socket` attribute so the debugger works regardless of what the host app provides.

## Changes

- **`lib/sagents_live_debugger/assets.ex`** (new) -- Compile-time JS bundler and Plug that serves the concatenated JS with MD5 cache-busting, including WebSocket-to-LongPoll fallback logic
- **`lib/sagents_live_debugger/router.ex`** -- Added `get "/js-:md5"` asset route, `root_layout` assignment, `live_socket_path` option, and `__sagents_debugger_prefix__/0` helper for URL generation
- **`lib/sagents_live_debugger/layouts.ex`** -- Split into `root/1` (HTML shell with script/meta tags) and `app/1` (passthrough); added `asset_path/2` and `live_socket_path/1` helpers
- **`lib/sagents_live_debugger/live/agent_list_live.ex`** -- Updated button classes from `.btn-back` to `.btn.btn-primary`
- **CSS** -- Promoted `.btn-primary` and `.btn-secondary` styles to global scope (previously scoped under `.filter-actions`)

## Testing

Manually tested by mounting the debugger in a Phoenix app that does not include LiveView JS assets in its own layout. Verified LiveSocket connects, live navigation works, and button styles render correctly.