### PR TITLE
Add cancelled state handling, structured sub-agent errors, live message updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -46,14 +46,16 @@ jobs:
             lint: lint
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           elixir-version: ${{ matrix.pair.elixir }}
           otp-version: ${{ matrix.pair.otp }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/lib/sagents_live_debugger/core_components.ex
+++ b/lib/sagents_live_debugger/core_components.ex
@@ -474,8 +474,7 @@ defmodule SagentsLiveDebugger.CoreComponents do
   defp highlight_with_lumis(code, language) when is_binary(code) do
     # Themes: dracula, onedark, material_oceanic
     Lumis.highlight!(code,
-      language: language,
-      formatter: {:html_inline, theme: "material_oceanic"}
+      formatter: {:html_inline, language: language, theme: "material_oceanic"}
     )
   rescue
     _ ->

--- a/lib/sagents_live_debugger/layouts.ex
+++ b/lib/sagents_live_debugger/layouts.ex
@@ -1608,6 +1608,10 @@ defmodule SagentsLiveDebugger.Layouts do
       border-left: 4px solid #ef4444;
     }
 
+    .subagent-entry.status-cancelled {
+      border-left: 4px solid #dc2626;
+    }
+
     .subagent-header {
       display: flex;
       align-items: center;
@@ -1666,6 +1670,37 @@ defmodule SagentsLiveDebugger.Layouts do
     .subagent-status-badge.status-error {
       background: #fee2e2;
       color: #991b1b;
+    }
+
+    /* Cancelled badge deliberately uses a bold solid-red scheme so it is
+       clearly distinct from the pastel running/completed/error states. */
+    .subagent-status-badge.status-cancelled {
+      background: #dc2626;
+      color: #ffffff;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    /* Terminal banner shown at the end of the messages list when an agent or
+       sub-agent was cancelled. Sits alongside the message-item style but is
+       deliberately not styled as a message so it reads as meta-info. */
+    .agent-cancelled-banner {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin: 0.75rem 0;
+      padding: 0.625rem 0.875rem;
+      background: #fee2e2;
+      border: 1px solid #fecaca;
+      border-left: 4px solid #dc2626;
+      border-radius: 4px;
+      color: #991b1b;
+      font-weight: 600;
+      font-size: 0.875rem;
+    }
+
+    .agent-cancelled-banner-icon {
+      font-size: 1rem;
     }
 
     /* Token usage badge */
@@ -1781,6 +1816,31 @@ defmodule SagentsLiveDebugger.Layouts do
     .subagent-error-content {
       background: #fef2f2 !important;
       color: #991b1b;
+    }
+
+    .subagent-error-structured {
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      border-radius: 4px;
+      padding: 0.5rem 0.75rem;
+      color: #991b1b;
+      font-size: 0.875rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .subagent-error-structured code {
+      background: #fee2e2;
+      padding: 0 0.25rem;
+      border-radius: 2px;
+    }
+
+    .subagent-final-messages {
+      max-height: 20rem;
+      overflow-y: auto;
+      border-left: 3px solid #fecaca;
+      padding-left: 0.5rem;
     }
 
     /* Streaming indicator */

--- a/lib/sagents_live_debugger/live/agent_list_live.ex
+++ b/lib/sagents_live_debugger/live/agent_list_live.ex
@@ -478,6 +478,34 @@ defmodule SagentsLiveDebugger.AgentListLive do
     {:noreply, socket}
   end
 
+  # Incremental rolling-state update: patches @agent_state.messages by appending
+  # the new messages, so the Messages tab updates live during a run instead of
+  # only after execute returns. Cheap relative to full-state broadcast.
+  def handle_info(
+        {:agent, {:debug, {:agent_state_messages_appended, new_messages}}},
+        socket
+      ) do
+    socket =
+      if socket.assigns.followed_agent_id != nil do
+        current = socket.assigns.agent_state
+
+        patched =
+          if current do
+            %{current | messages: (current.messages || []) ++ new_messages}
+          else
+            current
+          end
+
+        socket
+        |> assign(:agent_state, patched)
+        |> add_event_to_stream({:agent_state_messages_appended, new_messages}, :debug)
+      else
+        socket
+      end
+
+    {:noreply, socket}
+  end
+
   # Handle agent_state_update debug events (after execution completes)
   # This is the authoritative final state after the agent execution finishes
   def handle_info({:agent, {:debug, {:agent_state_update, new_state}}}, socket) do
@@ -1290,7 +1318,11 @@ defmodule SagentsLiveDebugger.AgentListLive do
                 agent_id={@selected_agent_id}
               />
             <% :messages -> %>
-              <.messages_tab state={@agent_state} agent={@agent_detail} />
+              <.messages_tab
+                state={@agent_state}
+                agent={@agent_detail}
+                agent_status={@agent_metadata && @agent_metadata.status}
+              />
             <% :middleware -> %>
               <.middleware_tab agent={@agent_detail} />
             <% :tools -> %>
@@ -1817,6 +1849,8 @@ defmodule SagentsLiveDebugger.AgentListLive do
 
   # Messages Tab
   defp messages_tab(assigns) do
+    assigns = assign_new(assigns, :agent_status, fn -> nil end)
+
     ~H"""
     <div class="messages-tab">
       <%= if @state && @state.messages do %>
@@ -1836,6 +1870,13 @@ defmodule SagentsLiveDebugger.AgentListLive do
             <%= for {message, index} <- Enum.with_index(@state.messages) do %>
               <.message_item message={message} index={index} />
             <% end %>
+          </div>
+        <% end %>
+
+        <%= if @agent_status == :cancelled do %>
+          <div class="agent-cancelled-banner">
+            <span class="agent-cancelled-banner-icon">🚫</span>
+            <span>Agent cancelled — execution stopped before completion.</span>
           </div>
         <% end %>
       <% else %>
@@ -2520,6 +2561,24 @@ defmodule SagentsLiveDebugger.AgentListLive do
     }
   end
 
+  defp format_subagent_event(sub_agent_id, {:subagent_failed_with_context, ctx}) do
+    %{
+      type: "subagent_failed_with_context",
+      sub_agent_id: sub_agent_id,
+      turn_count: ctx[:turn_count] || 0,
+      error: inspect(ctx[:error], limit: 100),
+      summary: "SubAgent #{short_id(sub_agent_id)} failed after #{ctx[:turn_count] || 0} turn(s)"
+    }
+  end
+
+  defp format_subagent_event(sub_agent_id, {:subagent_cancelled, _ctx}) do
+    %{
+      type: "subagent_cancelled",
+      sub_agent_id: sub_agent_id,
+      summary: "SubAgent #{short_id(sub_agent_id)} cancelled"
+    }
+  end
+
   defp format_subagent_event(sub_agent_id, {:subagent_llm_message, message}) do
     role = message.role || :unknown
 
@@ -2754,6 +2813,28 @@ defmodule SagentsLiveDebugger.AgentListLive do
 
   defp handle_subagent_event(socket, sub_agent_id, {:subagent_error, reason}) do
     update_subagent(socket, sub_agent_id, %{status: :error, error: reason})
+  end
+
+  # Structured failure: carries the final chain messages and turn count so the
+  # SubAgents tab can render "Last N messages before failure" alongside the
+  # error. The preceding :subagent_error event already set status/error; this
+  # event adds context.
+  defp handle_subagent_event(socket, sub_agent_id, {:subagent_failed_with_context, ctx}) do
+    update_subagent(socket, sub_agent_id, %{
+      status: :error,
+      error: ctx[:error],
+      final_messages: ctx[:final_messages] || [],
+      failure_turn_count: ctx[:turn_count] || 0
+    })
+  end
+
+  # Sub-agent cancelled because parent agent was cancelled.
+  # Only set status. The ctx from the fallback broadcast path (sub-agent was
+  # blocked in an LLM call) carries no messages; writing empty defaults would
+  # wipe out the messages this LiveView already accumulated from per-turn
+  # :subagent_llm_message events.
+  defp handle_subagent_event(socket, sub_agent_id, {:subagent_cancelled, _ctx}) do
+    update_subagent(socket, sub_agent_id, %{status: :cancelled})
   end
 
   # Catch-all for unhandled subagent events

--- a/lib/sagents_live_debugger/live/components/subagents_tab.ex
+++ b/lib/sagents_live_debugger/live/components/subagents_tab.ex
@@ -203,8 +203,32 @@ defmodule SagentsLiveDebugger.Live.Components.SubagentsTab do
       <%= if @subagent.error do %>
         <div class="subagent-config-item">
           <label class="subagent-error-label">Error:</label>
-          <.highlight_code code={inspect_for_display(@subagent.error)} />
+          <%= case @subagent.error do %>
+            <% %LangChain.LangChainError{} = err -> %>
+              <div class="subagent-error-structured">
+                <div>
+                  <strong>Type:</strong>
+                  <code>{err.type || "error"}</code>
+                </div>
+                <div><strong>Message:</strong> {err.message}</div>
+              </div>
+            <% other -> %>
+              <.highlight_code code={inspect_for_display(other)} />
+          <% end %>
         </div>
+
+        <%= if Map.get(@subagent, :final_messages, []) != [] do %>
+          <div class="subagent-config-item">
+            <label class="subagent-error-label">
+              Last {Map.get(@subagent, :failure_turn_count, length(@subagent.final_messages))} message(s) before failure:
+            </label>
+            <div class="subagent-final-messages">
+              <%= for message <- @subagent.final_messages do %>
+                <.message_item message={message} />
+              <% end %>
+            </div>
+          </div>
+        <% end %>
       <% end %>
     </div>
     """
@@ -241,6 +265,13 @@ defmodule SagentsLiveDebugger.Live.Components.SubagentsTab do
         <%= for message <- @subagent.messages do %>
           <.message_item message={message} />
         <% end %>
+      <% end %>
+
+      <%= if @subagent.status == :cancelled do %>
+        <div class="agent-cancelled-banner">
+          <span class="agent-cancelled-banner-icon">🚫</span>
+          <span>Sub-agent cancelled — no further messages will arrive.</span>
+        </div>
       <% end %>
     </div>
     """
@@ -312,6 +343,7 @@ defmodule SagentsLiveDebugger.Live.Components.SubagentsTab do
   defp status_entry_class(:running), do: "status-running"
   defp status_entry_class(:completed), do: "status-completed"
   defp status_entry_class(:interrupted), do: "status-interrupted"
+  defp status_entry_class(:cancelled), do: "status-cancelled"
   defp status_entry_class(:error), do: "status-error"
   defp status_entry_class(_), do: ""
 
@@ -319,6 +351,7 @@ defmodule SagentsLiveDebugger.Live.Components.SubagentsTab do
   defp status_badge_class(:running), do: "status-running"
   defp status_badge_class(:completed), do: "status-completed"
   defp status_badge_class(:interrupted), do: "status-interrupted"
+  defp status_badge_class(:cancelled), do: "status-cancelled"
   defp status_badge_class(:error), do: "status-error"
   defp status_badge_class(_), do: ""
 
@@ -326,6 +359,7 @@ defmodule SagentsLiveDebugger.Live.Components.SubagentsTab do
   defp format_status(:running), do: "Running"
   defp format_status(:completed), do: "Completed"
   defp format_status(:interrupted), do: "Interrupted"
+  defp format_status(:cancelled), do: "Cancelled"
   defp format_status(:error), do: "Error"
   defp format_status(other), do: to_string(other)
 


### PR DESCRIPTION
## Problem

Three pain points surfaced while watching long agent runs in the debugger:

1. The Messages tab only updated after `execute` returned, so during multi-turn tool runs the UI looked frozen.
2. When a user cancelled an agent, neither the main agent view nor any in-flight sub-agents indicated the cancellation — they just stopped.
3. Structured LangChain failures (context length exceeded, `:length` stops, etc.) rendered as raw `inspect` blobs, and the final chain state before a sub-agent crash was not surfaced at all.

Separately, `mix compile` emitted a Lumis warning after the upstream formatter API moved the `:language` option under `{:html_inline, ...}`, and CI had several zizmor-flagged issues (unpinned actions, persisted credentials, no dependabot).

## Solution

- Added a new `:agent_state_messages_appended` debug event handler in `AgentListLive` that patches `@agent_state.messages` incrementally during a run, so the Messages tab streams updates turn-by-turn instead of waiting for final `:agent_state_update`.
- Introduced a `:cancelled` status path for agents and sub-agents: a red "Agent cancelled" banner at the end of the messages list, a dedicated `status-cancelled` badge in the SubAgents tab, and a careful `handle_subagent_event/3` clause that updates only `:status` so accumulated streaming messages aren't wiped by a context-less fallback broadcast.
- Handled a new `:subagent_failed_with_context` event that carries `final_messages` and `turn_count`, rendered in the SubAgents tab as "Last N message(s) before failure" alongside a structured error view that pattern-matches `%LangChain.LangChainError{}` to show `type` + `message` cleanly.
- Moved the `:language` option into the `{:html_inline, ...}` tuple in `core_components.ex` to match current Lumis formatter signature.
- Hardened CI per zizmor: pinned `actions/checkout`, `erlef/setup-beam`, and `actions/cache` to commit SHAs with version comments, set `persist-credentials: false` on checkout, and added `.github/dependabot.yml` for weekly GitHub Actions updates.

## Changes

- `lib/sagents_live_debugger/live/agent_list_live.ex` — Added `:agent_state_messages_appended` handler for rolling state updates, plumbed `agent_status` into `messages_tab`, rendered cancelled banner, added `:subagent_failed_with_context` and `:subagent_cancelled` event formatters/handlers.
- `lib/sagents_live_debugger/live/components/subagents_tab.ex` — Structured rendering for `%LangChain.LangChainError{}`, "Last N messages before failure" block, and `:cancelled` support across `status_entry_class`, `status_badge_class`, and `format_status`.
- `lib/sagents_live_debugger/layouts.ex` — New CSS for `.agent-cancelled-banner`, `.status-cancelled` badge, `.subagent-error-structured`, and `.subagent-final-messages`.
- `lib/sagents_live_debugger/core_components.ex` — Updated Lumis `highlight!` call to pass `:language` inside the `:html_inline` formatter tuple (fixes compiler warning).
- `.github/workflows/elixir.yml` — Pinned actions to commit SHAs, set `persist-credentials: false`.
- `.github/dependabot.yml` — New file; weekly GitHub Actions updates with 7-day cooldown.

## Testing

Verified manually in the debugger UI:
- Cancelled a running agent mid tool-chain and confirmed the red banner appears on both the main Messages tab and any active sub-agent message lists.
- Forced a context-length failure in a sub-agent and confirmed the structured error (type + message) renders with the trailing final messages.
- Watched a long continuous tool-turn run and confirmed messages now appear as they complete instead of all at once at the end.
- `mix compile` is warning-free against the current Lumis version.
- CI workflow lint path still passes with the pinned actions.