### PR TITLE
Include priv/ in hex package so CSS assets ship with the library

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -83,6 +83,7 @@ defmodule SagentsLiveDebugger.MixProject do
     [
       files: [
         "lib",
+        "priv",
         ".formatter.exs",
         "mix.exs",
         "README*",


### PR DESCRIPTION
## Problem

The `priv/` directory was not listed in the `files` entry of `mix.exs`, so CSS assets under `priv/static` were excluded from the published hex package. Host applications embedding `sagents_live_debugger` rendered the debugger page without styles.

## Solution

Added `"priv"` to the `files` list in the `package/0` definition in `mix.exs` so hex includes the directory when packaging the release.

## Changes

- `mix.exs` — added `"priv"` to the package `files` list

## Testing

Change is confined to hex packaging metadata. Verify by running `mix hex.build` and inspecting the tarball contents, or by consuming the built package from a host app and confirming the debugger page loads with styles applied.